### PR TITLE
Ensure that driver memory setting is used.

### DIFF
--- a/spylon/spark/launcher.py
+++ b/spylon/spark/launcher.py
@@ -306,6 +306,9 @@ class _SparkConfHelper(object):
     def __setitem__(self, key, value):
         self._conf_dict[key] = value
 
+    def __getitem__(self, key):
+        return self._conf_dict[key]
+
     def set(self, key, value):
         """Set a particular spark property by the string key name.
 
@@ -438,6 +441,15 @@ class SparkConfiguration(object):
     def _set_environment_variables(self):
         """Initializes the correct environment variables for spark"""
         cmd = []
+
+        # special case for driver memory.
+        # Since this can be set erroneously on the standard spark conf we want to be able to just pick that up if
+        # present, since other the setting is IGNORED when starting up the spark daemon.
+        driver_memory = self._spark_launcher_args.get("driver-memory", self.conf._conf_dict.get("spark.driver.memory"))
+        if driver_memory:
+            self._spark_launcher_args["driver-memory"] = driver_memory
+            self.conf["spark.driver.memory"] = driver_memory
+
         for key, val in self._spark_launcher_args.items():
             if val is None:
                 continue

--- a/tests/test_spark_launcher.py
+++ b/tests/test_spark_launcher.py
@@ -28,3 +28,10 @@ def test_spark_launcher_multiple_argument():
     c.archives = archive
     c._set_environment_variables()
     assert ('--archives ' + ','.join(archive)) in os.environ['PYSPARK_SUBMIT_ARGS']
+
+
+def test_spark_driver_memory():
+    c = sparklauncher.SparkConfiguration()
+    c.conf.spark.driver.memory = "5g"
+    c._set_environment_variables()
+    assert '--driver-memory 5g' in os.environ['PYSPARK_SUBMIT_ARGS']


### PR DESCRIPTION
When a user sets `spark.driver.memory` this normally only applies to spark programs that are launched in cluster mode.  

Since this is a pretty major gotcha it feels safer to just use this setting if specified by the user for the argument that ultimately becomes the `--driver-memory` command line argument.