### PR TITLE
Update doctr deploy API usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ script:
   # remove the container that we built
   - docker rm spylon-docs
   # On pushes push the docs to gh-pages
-  - doctr deploy
+  - doctr deploy docs


### PR DESCRIPTION
Deploy directory is now a required argument for `doctr` and `--gh-pages-docs` is deprecated.