### PR TITLE
Update doctr deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ script:
   # remove the container that we built
   - docker rm spylon-docs
   # On pushes push the docs to gh-pages
-  - doctr deploy
+  - doctr deploy docs


### PR DESCRIPTION
The `--gh-pages-docs` flag is deprecated and the deploy directory is now a required argument.