### PR TITLE
Another attempt at getattr

### DIFF
--- a/spylon/spark/launcher.py
+++ b/spylon/spark/launcher.py
@@ -390,7 +390,8 @@ class SparkConfiguration(object):
         spark_arg = key.replace('_', '-')
         if key.startswith("_"):
             return super(SparkConfiguration, self).__setattr__(key, value)
-
+        if spark_arg not in self._spark_launcher_arg_names:
+            raise AttributeError('%s object has no attribute %s' % (self.__class__.__name__, key))
         if spark_arg in self._spark_launcher_arg_names:
             self._spark_launcher_args[spark_arg] = value
 
@@ -399,9 +400,8 @@ class SparkConfiguration(object):
         if key.startswith("_"):
             return super(SparkConfiguration, self).__getattribute__(key)
         spark_arg = key.replace('_', '-')
-        attr_err = '%s object has no attribute %s' % (self.__class__.__name__, key)
         if spark_arg not in self._spark_launcher_arg_names:
-            raise AttributeError(attr_err)
+            raise AttributeError('%s object has no attribute %s' % (self.__class__.__name__, key))
         return self._spark_launcher_args.get(spark_arg)
 
     def __setitem__(self, key, val):

--- a/spylon/spark/launcher.py
+++ b/spylon/spark/launcher.py
@@ -402,10 +402,7 @@ class SparkConfiguration(object):
         attr_err = '%s object has no attribute %s' % (self.__class__.__name__, key)
         if spark_arg not in self._spark_launcher_arg_names:
             raise AttributeError(attr_err)
-        try:
-            return self._spark_launcher_args[spark_arg]
-        except KeyError:
-            raise AttributeError(attr_err)
+        return self._spark_launcher_args.get(spark_arg)
 
     def __setitem__(self, key, val):
         return self._spark_conf.__setitem__(key, val)

--- a/spylon/spark/launcher.py
+++ b/spylon/spark/launcher.py
@@ -399,8 +399,13 @@ class SparkConfiguration(object):
         if key.startswith("_"):
             return super(SparkConfiguration, self).__getattribute__(key)
         spark_arg = key.replace('_', '-')
-        if spark_arg in self._spark_launcher_arg_names:
-            return self._spark_launcher_args.get(spark_arg)
+        attr_err = '%s object has no attribute %s' % (self.__class__.__name__, key)
+        if spark_arg not in self._spark_launcher_arg_names:
+            raise AttributeError(attr_err)
+        try:
+            return self._spark_launcher_args[spark_arg]
+        except KeyError:
+            raise AttributeError(attr_err)
 
     def __setitem__(self, key, val):
         return self._spark_conf.__setitem__(key, val)

--- a/spylon/spark/launcher.py
+++ b/spylon/spark/launcher.py
@@ -367,8 +367,12 @@ class SparkConfiguration(object):
         p.end_group(1, ')')
 
     def __init__(self, python_path=None, spark_conf=None, spark_launcher_args=None):
-        self._spark_launcher_args = spark_launcher_args or self._default_spark_launcher_args
-        self._python_path = python_path or "python"
+        if spark_launcher_args is None:
+            spark_launcher_args = SparkConfiguration._default_spark_launcher_args.copy()
+        self._spark_launcher_args = spark_launcher_args
+        if python_path is None:
+            python_path = "python"
+        self._python_path = python_path
         self._spark_home = None
         self._spark_conf_helper = _SparkConfHelper(existing_conf=spark_conf or self._default_spark_conf)
 

--- a/tests/test_spark_launcher.py
+++ b/tests/test_spark_launcher.py
@@ -5,6 +5,10 @@ import os
 __author__ = 'mniekerk'
 
 
+def test_sparkconf_hasattr():
+    c = sparklauncher.SparkConfiguration()
+    assert hasattr(c, "foo") is False
+
 def test_spark_property():
     c = sparklauncher.SparkConfiguration()
     c.conf.spark.executor.cores = 5

--- a/tests/test_spark_launcher.py
+++ b/tests/test_spark_launcher.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, absolute_import
 import spylon.spark.launcher as sparklauncher
 import os
+import pytest
 
 __author__ = 'mniekerk'
 
@@ -13,7 +14,14 @@ def test_sparkconf_hasattr():
     assert c.driver_memory is None
     c.driver_memory = "4g"
     assert c.driver_memory == "4g"
-
+    with pytest.raises(AttributeError):
+        # make sure that attempting to access unknown variables raises an attribute error
+        getattr(c, 'foo')
+    with pytest.raises(AttributeError):
+        # make sure that attempting to set unknown variables raises an attribute error
+        c.foo = "bar"
+        
+                
 def test_spark_property():
     c = sparklauncher.SparkConfiguration()
     c.conf.spark.executor.cores = 5

--- a/tests/test_spark_launcher.py
+++ b/tests/test_spark_launcher.py
@@ -8,6 +8,8 @@ __author__ = 'mniekerk'
 def test_sparkconf_hasattr():
     c = sparklauncher.SparkConfiguration()
     assert hasattr(c, "foo") is False
+    assert hasattr(c, "driver_memory") is True
+    assert hasattr(c, "driver-memory") is True
 
 def test_spark_property():
     c = sparklauncher.SparkConfiguration()

--- a/tests/test_spark_launcher.py
+++ b/tests/test_spark_launcher.py
@@ -10,6 +10,9 @@ def test_sparkconf_hasattr():
     assert hasattr(c, "foo") is False
     assert hasattr(c, "driver_memory") is True
     assert hasattr(c, "driver-memory") is True
+    assert c.driver_memory is None
+    c.driver_memory = "4g"
+    assert c.driver_memory == "4g"
 
 def test_spark_property():
     c = sparklauncher.SparkConfiguration()


### PR DESCRIPTION
Need to clean up the "fixed" implementation of `__getattr__`  in #39 because
returning None is interpreted as the object having the attr in question.
Clearly that is incorrect...

attn @parente